### PR TITLE
add an org profile

### DIFF
--- a/profile/README.md
+++ b/profile/README.md
@@ -1,0 +1,11 @@
+## Welcome to the Development Containers Community
+
+In this community we maintain the [Development Containers (dev container) Specification](https://containers.dev). The dev container spec defines a standard for any development tool to use a container as a full-featured development environment. Join us to continue to make this spec and the reference CLI implementation even better by joining the [discussion](https://github.com/orgs/devcontainers/discussions) or opening issues on the relevant repository.
+
+The dev containers specification is maintained in the [spec repo](https://github.com/devcontainers/spec). 
+
+The community maintains a set of [images](https://github.com/devcontainers/images) for use as and [features](https://github.com/devcontainers/features) for your dev containers. 
+
+Publish your own features using the [features template repo](https://github.com/devcontainers/feature-template).
+
+The https://containers.dev site is in the [devcontainers.github.io repo](https://github.com/devcontainers/devcontainers.github.io).

--- a/profile/README.md
+++ b/profile/README.md
@@ -6,6 +6,6 @@ The dev containers specification is maintained in the [spec repo](https://github
 
 We maintain a set of [images](https://github.com/devcontainers/images) and [Features](https://github.com/devcontainers/features) as part of the specification.
 
-Publish your own features using the [features template repo](https://github.com/devcontainers/feature-template).
+You can also [create and share your own Features](https://containers.dev/implementors/create-feature/). We've created a [Features template repo](https://github.com/devcontainers/feature-template) to help along the way.
 
 The https://containers.dev site is in the [devcontainers.github.io repo](https://github.com/devcontainers/devcontainers.github.io).

--- a/profile/README.md
+++ b/profile/README.md
@@ -1,6 +1,11 @@
 ## Welcome to the Development Containers Community
 
-In this community we maintain the [Development Containers (dev container) Specification](https://containers.dev). The dev container spec defines a standard for any development tool to use a container as a full-featured development environment. Join us to continue to make this spec and the reference CLI implementation even better by joining the [discussion](https://github.com/orgs/devcontainers/discussions) or opening issues on the relevant repository.
+In this community we maintain the [Development Containers (dev container) Specification](https://containers.dev). The dev container spec defines a standard for any development tool to use a container as a full-featured development environment. 
+
+Join us to continue to make this spec and the reference CLI implementation even better! There are several ways you can chat with the spec maintainers and the community:
+* Open a GitHub [Discussion](https://github.com/orgs/devcontainers/discussions)
+* Open issues on the relevant repository in the `devcontainers` org
+* Join our Slack channel! You may reply to [this Discussion](https://github.com/devcontainers/community/discussions/3) to get added
 
 The dev containers specification is maintained in the [spec repo](https://github.com/devcontainers/spec). 
 

--- a/profile/README.md
+++ b/profile/README.md
@@ -4,7 +4,7 @@ In this community we maintain the [Development Containers (dev container) Specif
 
 The dev containers specification is maintained in the [spec repo](https://github.com/devcontainers/spec). 
 
-The community maintains a set of [images](https://github.com/devcontainers/images) for use as and [features](https://github.com/devcontainers/features) for your dev containers. 
+We maintain a set of [images](https://github.com/devcontainers/images) and [Features](https://github.com/devcontainers/features) as part of the specification.
 
 Publish your own features using the [features template repo](https://github.com/devcontainers/feature-template).
 


### PR DESCRIPTION
Make the org landing page at https://github.com/devcontainers more informative and welcoming